### PR TITLE
PI-646 Fix nginx configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/salt/top.sls
 *~
 *.pyc
 *.orig

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+elifeFormula('elife-api')

--- a/salt/elife-api/config/etc-nginx-sitesavailable-elifeapi-https.conf
+++ b/salt/elife-api/config/etc-nginx-sitesavailable-elifeapi-https.conf
@@ -39,7 +39,6 @@ server {
         include /etc/uwsgi/params;
     }
 }
-}
 
 # configuration of the server
 server {


### PR DESCRIPTION
The original nginx state doesn't notice the typo:
```
    elife-api--vagrant:           ID: listener_nginx-server-service
    elife-api--vagrant:     Function: service.mod_watch
    elife-api--vagrant:         Name: nginx
    elife-api--vagrant:       Result: True
    elife-api--vagrant:      Comment: Service restarted
    elife-api--vagrant:      Started: 17:46:49.588418
    elife-api--vagrant:     Duration: 47.784 ms
    elife-api--vagrant:      Changes:   
    elife-api--vagrant:               ----------
    elife-api--vagrant:               nginx:
    elife-api--vagrant:                   True
```

It is true nginx will refuse to restart and keep the old configuration now... but on a new server this is not useful as there is no virtual host defined for elife-api.