### PR TITLE
[wip] Feature: 1804 upgrade

### DIFF
--- a/salt/elife-api/config/etc-nginx-sitesenabled-elifeapi-https.conf
+++ b/salt/elife-api/config/etc-nginx-sitesenabled-elifeapi-https.conf
@@ -4,7 +4,7 @@ upstream django {
     server unix:/tmp/elife-api-uwsgi.sock;
     {% else %}
     # socket is now managed by systemd
-    server unix:///var/run/uwsgi/lax.socket;
+    server unix:///var/run/uwsgi/elife-api.socket;
     {% endif %}
 }
 
@@ -19,32 +19,6 @@ server {
 }
 {% endif %}
 
-server {
-    # we always listen on port 80.
-    # in non-dev environments port 80 is only available to internal traffic
-    listen      80;
-
-    listen      443 ssl; # see /etc/nginx/nginx.conf for global ssl settings
-    server_name api.elifesciences.org;
-
-    access_log /var/log/nginx/dependencies-elife-api.access.log combined_with_time;
-    error_log /var/log/nginx/dependencies-elife-api.error.log;
-
-    # used for Swagger and admin
-    location /static {
-        alias /srv/elife-api/collected-static;
-    }
-
-    # all non-media requests
-    location / {
-        uwsgi_pass django;
-        # drop connection after this many seconds
-        # WARNING: this value *must* be higher than uwsgi's 'harakiri' value
-        # (10s) in /srv/elife-api/uwsgi.ini
-        uwsgi_read_timeout 15s;
-        include /etc/uwsgi/params;
-    }
-}
 
 # configuration of the server
 server {
@@ -53,10 +27,8 @@ server {
     listen      80;
     {% if salt['elife.cfg']('cfn.outputs.DomainName') %}
     listen      443 ssl; # see /etc/nginx/nginx.conf for global ssl settings
-    server_name {{ salt['elife.cfg']('project.full_hostname') }}
-                {{ salt['elife.cfg']('project.int_project_hostname') }}
-                {{ salt['elife.cfg']('project.int_full_hostname') }}
-                master.api.elifesciences.org;
+    server_name {{ salt['elife.cfg']('project.project_hostname') }}
+                {{ salt['elife.cfg']('project.full_hostname') }};
     {% else %}
     server_name localhost;
     {% endif %}
@@ -69,6 +41,7 @@ server {
     # max upload size
     client_max_body_size 5M;
 
+    # lsh@2019-09-23, no longer necessary
     # used for Swagger and admin
     location /static {
         alias /srv/elife-api/collected-static;

--- a/salt/elife-api/config/etc-nginx-sitesenabled-elifeapi-https.conf
+++ b/salt/elife-api/config/etc-nginx-sitesenabled-elifeapi-https.conf
@@ -1,6 +1,11 @@
 # the upstream component nginx needs to connect to
 upstream django {
+    {% if salt['grains.get']('osrelease') == "14.04" %}
     server unix:/tmp/elife-api-uwsgi.sock;
+    {% else %}
+    # socket is now managed by systemd
+    server unix:///var/run/uwsgi/lax.socket;
+    {% endif %}
 }
 
 {% if salt['elife.cfg']('cfn.outputs.DomainName') %}
@@ -14,8 +19,9 @@ server {
 }
 {% endif %}
 
-
 server {
+    # we always listen on port 80.
+    # in non-dev environments port 80 is only available to internal traffic
     listen      80;
 
     listen      443 ssl; # see /etc/nginx/nginx.conf for global ssl settings

--- a/salt/elife-api/config/srv-elife-api-app.cfg
+++ b/salt/elife-api/config/srv-elife-api-app.cfg
@@ -1,7 +1,7 @@
 [general]
 debug: false
 secret-key: {{ pillar.elife_api.secret }}
-allowed-hosts: legacy--api.elifesciences.org,api.elifesciences.org,.api.elifesciences.org,api.elife.internal,.api.elife.internal
+allowed-hosts: legacy--api.elifesciences.org
 
 [database]
 name: %(dir)s/db.sqlite3

--- a/salt/elife-api/config/srv-elifeapi-uwsgi.ini
+++ b/salt/elife-api/config/srv-elifeapi-uwsgi.ini
@@ -1,23 +1,61 @@
 [uwsgi]
 chdir=/srv/elife-api/src/
-uid={{ pillar.elife.webserver.username }}
-gid={{ pillar.elife.webserver.username }}
 pythonpath=/srv/elife-api/src/
 
+{% if salt['grains.get']('osrelease') == "14.04" %}
+
+uid={{ pillar.elife.webserver.username }}
+gid={{ pillar.elife.webserver.username }}
 socket = /tmp/elife-api-uwsgi.sock
 chmod-socket = 666
-
 logto = /var/log/uwsgi.log
+
+{% else %}
+
+# systemd service now handles dropping permissions
+#uid={{ pillar.elife.webserver.username }}
+#gid={{ pillar.elife.webserver.username }}
+
+# systemd now handles the socket
+# this fixes many problems restarting uwsgi service with systemd
+# your nginx conf file needs the new location of this socket
+# see /lib/systemd/system/uwsgi-elife-metrics.socket
+#socket = /tmp/appname-uwsgi.sock
+#chmod-socket = 666
+
+# moved to the systemd service file
+# quite possibly *all* of this file could become global defaults
+#logto = /var/log/uwsgi.log
+
+# further options for uwsgi+systemd:
+#   https://uwsgi-docs.readthedocs.io/en/latest/Systemd.html#one-service-per-app-in-systemd
+
+# 'cheap' mode, don't spawn workers until first request
+#   https://uwsgi-docs.readthedocs.io/en/latest/Options.html?highlight=cheap#uwsgi-options
+cheap=True
+# "automatically rewrite SCRIPT_NAME and PATH_INFO"
+#   https://uwsgi-docs.readthedocs.io/en/latest/Options.html?highlight=cheap#manage-script-name
+manage-script-name=True
+
+{% endif %}
 
 module=core.wsgi:application
 virtualenv=/srv/elife-api/venv/
 master=True
-chmod-socket = 666
+# time to revisit this?
 processes=1
-
+#threads=2
 vacuum=True
-
 max-requests=5000
 
 # kill self after this many seconds
 harakiri = 10
+
+# By default uWSGI will execute Python code within a sub interpreter of the process rather than the main Python interpreter 
+# created when Python is first initialized. This is done to allow multiple separate Python web applications to be run within 
+# the one process but to be sufficiently separated so as to not interfere with each other. Older versions of uWSGI can fail 
+# however when using sub interpreters with threading enabled. It is therefore safest to use this option and restrict yourself 
+# to a single web application per process. Running a single web application in each process with uWSGI is the normal use case 
+# so it would be unlikely that this restriction would be an issue.
+# - https://docs.newrelic.com/docs/agents/python-agent/hosting-mechanisms/python-agent-uwsgi
+single-interpreter = True

--- a/salt/elife-api/init.sls
+++ b/salt/elife-api/init.sls
@@ -1,9 +1,10 @@
 elife-api-repo:
-    git.latest:
-        - name: https://github.com/elifesciences/elife-api.git
+    builder.git_latest:
+        - name: git@github.com:elifesciences/elife-api.git
+        - identity: {{ pillar.elife.projects_builder.key or '' }}
+        - rev: master
+        - branch: master
         - target: /srv/elife-api/
-        - rev: {{ salt['elife.cfg']('project.branch', 'master') }}
-        - branch: {{ salt['elife.cfg']('project.branch', 'master') }}
         - force_fetch: True
         - force_checkout: True
         - force_reset: True
@@ -17,16 +18,27 @@ elife-api-dir:
             - user
             - group
         - require:
-            - git: elife-api-repo
+            - elife-api-repo
 
 elife-api-virtualenv:
-    virtualenv.managed:
+    cmd.run:
         - user: {{ pillar.elife.deploy_user.username }}
-        - name: /srv/elife-api/venv/
+        - name: ./install.sh
         - cwd: /srv/elife-api/
-        - requirements: /srv/elife-api/requirements.txt
         - require:
             - file: elife-api-dir
+
+# todo: remove once uwsgi available in elife-api/requirements.txt
+elife-api-uwsgi-hack:
+    cmd.run:
+        - cwd: /srv/elife-api/
+        - user: {{ pillar.elife.deploy_user.username }}
+        - name: |
+            set -e
+            source venv/bin/activate
+            pip install "uWSGI==2.0.17.1"
+        - require:
+            - elife-api-virtualenv
 
 cfg-file:
     file.managed:
@@ -46,6 +58,6 @@ collect-static:
         - name: ./manage.sh collectstatic --noinput
         - require:
             - file: cfg-file
-            - virtualenv: elife-api-virtualenv
+            - cmd: elife-api-virtualenv
         - watch_in:
             - service: nginx-server-service

--- a/salt/elife-api/init.sls
+++ b/salt/elife-api/init.sls
@@ -28,18 +28,6 @@ elife-api-virtualenv:
         - require:
             - file: elife-api-dir
 
-# todo: remove once uwsgi available in elife-api/requirements.txt
-elife-api-uwsgi-hack:
-    cmd.run:
-        - cwd: /srv/elife-api/
-        - user: {{ pillar.elife.deploy_user.username }}
-        - name: |
-            set -e
-            source venv/bin/activate
-            pip install "uWSGI==2.0.17.1"
-        - require:
-            - elife-api-virtualenv
-
 cfg-file:
     file.managed:
         - user: {{ pillar.elife.deploy_user.username }}
@@ -51,6 +39,7 @@ cfg-file:
         - require:
             - file: elife-api-dir
 
+# no long necessary
 collect-static:
     cmd.run:
         - user: {{ pillar.elife.deploy_user.username }}

--- a/salt/elife-api/uwsgi.sls
+++ b/salt/elife-api/uwsgi.sls
@@ -2,9 +2,7 @@ elife-api-nginx-conf:
     file.managed:
         - name: /etc/nginx/sites-enabled/elife-api.conf
         - template: jinja
-        - source: salt://elife-api/config/etc-nginx-sitesavailable-elifeapi-https.conf
-        - require:
-            - git: elife-api-repo
+        - source: salt://elife-api/config/etc-nginx-sitesenabled-elifeapi-https.conf
 
 elife-api-uwsgi-conf:
     file.managed:
@@ -12,21 +10,38 @@ elife-api-uwsgi-conf:
         - source: salt://elife-api/config/srv-elifeapi-uwsgi.ini
         - template: jinja
         - require:
-            - git: elife-api-repo
-            
-elife-api-uwsgi:
+            - elife-api-repo
+
+{% if salt['grains.get']('osrelease') == "14.04" %}
+
+# v.old
+elife-api-init-script:
     file.managed:
         - name: /etc/init.d/elife-api-uwsgi
         - source: salt://elife-api/config/etc-init.d-elife-api-uwsgi
         - mode: 755
+        - require_in:
+            - service: elife-api-uwsgi
 
+{% else %}
+
+uwsgi-elife-api.socket:
     service.running:
         - enable: True
         - require:
-            - file: elife-api-uwsgi
+            - file: uwsgi-socket-elife-api # builder-base-formula.uwsgi
+        - require_in:
+            - service: elife-api-uwsgi
+
+{% endif %}
+
+elife-api-uwsgi:
+    service.running:
+        - enable: True
+        - require:
             - file: elife-api-uwsgi-conf
-            - file: uwsgi-params
-            - uwsgi-pkg
+            - file: uwsgi-params # builder-base-formula/salt/elife/uwsgi-params.sls (included by uwsgi.sls)
+            - uwsgi-pkg # no longer installs uwsgi globally since 16.04+
         - watch:
             - service: nginx-server-service
 

--- a/salt/pillar/elife-api.sls
+++ b/salt/pillar/elife-api.sls
@@ -1,2 +1,8 @@
 elife_api:
     secret: "secret-key-do-not-use-in-prd"
+
+elife:
+    uwsgi:
+        services:
+            elife-api:
+                folder: /srv/elife-api


### PR DESCRIPTION
upgrades elife-api project to Ubuntu 18.04

* most of the changes are copied from the lax formula
* some of the `master.api.elifesciences.org` and `api.elifesciences.org` support have been removed. DNS for this repointed ages ago

currently some issues with the systemd services but I'll make another pass this week depending on what Graham says about disconnecting elife-api from lens

fyi @giorgiosironi 